### PR TITLE
feat: add init container

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "services/nginx"]
 	path = services/nginx
 	url = https://github.com/placeos/nginx.git
+[submodule "services/init"]
+	path = services/init
+	url = https://github.com/placeos/init.git


### PR DESCRIPTION
Given that the `init` container is yet to be extracted, it's still fundamental to a relase so it should be included here for the time being.