### PR TITLE
feat: seperate image build and publish steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,14 @@ jobs:
       id: version
       run: |
         branch=$(git branch --show-current)
-        if [ $branch == "nightly" ]
+        if [[ $branch =~ ^[0-9]+\.[0-9]{4}$ ]]
         then
-          echo ::set-output name=tag::$branch
-        else
+          echo ::debug::Generating platform version
           offset=$(git rev-list origin/nightly.. --count)
           echo ::set-output name=tag::placeos-$branch.$offset
+        else
+          echo ::debug::Not on a release branch, using branch name
+          echo ::set-output name=tag::$branch
         fi
     - name: Discover services
       id:   introspect

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
     - name: Checkout release
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.ref }}
         fetch-depth: 0
     - name: Generate version number
       id: version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,4 +127,9 @@ jobs:
         done
     -
       name: Publish
-      run:  for service in *; do docker push placeos/$service; done
+      run:  |
+        for service in *; do
+          echo ::group::$service
+          docker push placeos/$service
+          echo ::endgroup::
+        done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,17 +83,20 @@ jobs:
         path: image.tar
 
   publish-images:
-    needs: [platform-info, build-services]
+    needs: build-services
     runs-on: ubuntu-latest
-    name: Publish service images
+    name: Publish
     steps:
     - name: Login to DockerHub
-      if: false
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Download all service artifacts
+    - name: Download service artifacts
       uses: actions/download-artifact@v2
-    - name: Show build output (temp)
-      run:  ls -R
+    - name: Load images locally
+      run: |
+        for service in ./*; do
+          echo ::debug::Loading $service
+          docker load --input $service/image.tar
+        done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,4 +108,4 @@ jobs:
     - name: Load images
       run:  for service in *; do docker load --input $service/image.tar; done
     - name: Publish
-      run:  for service in *; do docker push $service; done
+      run:  for service in *; do docker push placeos/$service; done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,16 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ matrix.service.repo }}#${{ matrix.service.ref }}
-        tags: placeos/${{ matrix.service.name }}:${{ needs.platform-info.outputs.version }}
         build-args: PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
         outputs: type=oci,dest=image.tar
+        tags: placeos/${{ matrix.service.name }}:${{ needs.platform-info.outputs.version }}
+        labels: |
+          org.opencontainers.image.url=${{ matrix.service.repo }}
+          org.opencontainers.image.source=${{ matrix.service.repo }}/tree/${{ matrix.service.ref }}
+          org.opencontainers.image.version=${{ needs.platform-info.outputs.version }}
+          org.opencontainers.image.revision=${{ matrix.service.ref }}
+          org.opencontainers.image.vendor=Place Technology Limited
+          org.opencontainers.image.title=${{ matrix.service.name }}
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,8 @@ jobs:
               name: .[0],
               path: .[1],
               repo: .[2],
-              ref:  .[3]
+              href: .[2][:-4],
+              sha:  .[3],
             }
           ]'
         )
@@ -75,15 +76,15 @@ jobs:
       id:   build
       uses: docker/build-push-action@v2
       with:
-        context: ${{ matrix.service.repo }}#${{ matrix.service.ref }}
+        context: ${{ matrix.service.repo }}#${{ matrix.service.sha }}
         build-args: PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
         outputs: type=oci,dest=image.tar
         tags: placeos/${{ matrix.service.name }}:${{ needs.platform-info.outputs.version }}
         labels: |
-          org.opencontainers.image.url=${{ matrix.service.repo }}
-          org.opencontainers.image.source=${{ matrix.service.repo }}/tree/${{ matrix.service.ref }}
+          org.opencontainers.image.url=${{ matrix.service.href }}
+          org.opencontainers.image.source=${{ matrix.service.href }}/tree/${{ matrix.service.sha }}
           org.opencontainers.image.version=${{ needs.platform-info.outputs.version }}
-          org.opencontainers.image.revision=${{ matrix.service.ref }}
+          org.opencontainers.image.revision=${{ matrix.service.sha }}
           org.opencontainers.image.vendor=Place Technology Limited
           org.opencontainers.image.title=${{ matrix.service.name }}
     - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
     strategy:
       matrix:
         service: ${{ fromJson(needs.platform-info.outputs.services) }}
+      fail-fast: false
     runs-on: ubuntu-latest
     name: Build ${{ matrix.service.name }}
     steps:
@@ -67,16 +68,32 @@ jobs:
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and push
+    - name: Build image
       id:   build
       uses: docker/build-push-action@v2
       with:
         context: ${{ matrix.service.repo }}#${{ matrix.service.ref }}
-        push: true
         tags: placeos/${{ matrix.service.name }}:${{ needs.platform-info.outputs.version }}
         build-args: PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
+        outputs: type=oci,dest=image.tar
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.service.name }}
+        path: image.tar
+
+  publish-images:
+    needs: [platform-info, build-services]
+    runs-on: ubuntu-latest
+    name: Publish service images
+    steps:
+    - name: Login to DockerHub
+      if: false
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Download all service artifacts
+      uses: actions/download-artifact@v2
+    - name: Show build output (temp)
+      run:  ls -R

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       with:
         context: ${{ matrix.service.repo }}#${{ matrix.service.sha }}
         build-args: PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
-        outputs: type=oci,dest=image.tar
+        outputs: type=docker,dest=image.tar
         tags: placeos/${{ matrix.service.name }}:${{ needs.platform-info.outputs.version }}
         labels: |
           org.opencontainers.image.url=${{ matrix.service.href }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - '[0-9].[0-9][0-9][0-9][0-9]'
+  workflow_dispatch:
 
 jobs:
   platform-info:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,11 @@ on:
     workflows: [Update]
     branches: [nightly]
     types: [completed]
+
   push:
     branches:
       - '[0-9].[0-9][0-9][0-9][0-9]'
+
   workflow_dispatch:
 
 jobs:
@@ -19,11 +21,13 @@ jobs:
       version: ${{ steps.version.outputs.tag }}
     name: Prepare
     steps:
-    - name: Checkout release
+    -
+      name: Checkout release
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Generate version number
+    -
+      name: Generate version number
       id: version
       run: |
         branch=$(git branch --show-current)
@@ -36,7 +40,8 @@ jobs:
           echo ::debug::Not on a release branch, using branch name
           echo ::set-output name=tag::$branch
         fi
-    - name: Discover services
+    -
+      name: Discover services
       id:   introspect
       run: |
         echo ::set-output name=commit::$(git rev-parse HEAD)
@@ -68,11 +73,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Build ${{ matrix.service.name }}
     steps:
-    - name: Set up QEMU
+    -
+      name: Set up QEMU
       uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
+    -
+      name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Build image
+    -
+      name: Build image
       id:   build
       uses: docker/build-push-action@v2
       with:
@@ -87,7 +95,8 @@ jobs:
           org.opencontainers.image.revision=${{ matrix.service.sha }}
           org.opencontainers.image.vendor=Place Technology Limited
           org.opencontainers.image.title=${{ matrix.service.name }}
-    - name: Upload artifact
+    -
+      name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.service.name }}
@@ -98,14 +107,17 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish
     steps:
-    - name: Login to DockerHub
+    -
+      name: Login to DockerHub
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Download service artifacts
+    -
+      name: Download service artifacts
       uses: actions/download-artifact@v2
-    - name: Load images
+    -
+      name: Load images
       run:  |
         for service in *; do
           echo ::group::$service
@@ -113,5 +125,6 @@ jobs:
           awk '{print $NF}' | xargs docker inspect
           echo ::endgroup::
         done
-    - name: Publish
+    -
+      name: Publish
       run:  for service in *; do docker push placeos/$service; done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,9 +94,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Download service artifacts
       uses: actions/download-artifact@v2
-    - name: Load images locally
-      run: |
-        for service in ./*; do
-          echo ::debug::Loading $service
-          docker load --input $service/image.tar
-        done
+    - name: Load images
+      run:  for service in *; do docker load --input $service/image.tar; done
+    - name: Publish
+      run:  for service in *; do docker push $service; done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - '[0-9].[0-9][0-9][0-9][0-9]'
 
-  workflow_dispatch:
-
 jobs:
   platform-info:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,12 @@ jobs:
     - name: Download service artifacts
       uses: actions/download-artifact@v2
     - name: Load images
-      run:  for service in *; do docker load --input $service/image.tar; done
+      run:  |
+        for service in *; do
+          echo ::group::$service
+          docker load --input $service/image.tar |
+          awk '{print $NF}' | xargs docker inspect
+          echo ::endgroup::
+        done
     - name: Publish
       run:  for service in *; do docker push placeos/$service; done


### PR DESCRIPTION
This refactors the build workflow to:
1. Attempt to build all service images in parallel. If one fails, others will continue to build so that any associated issues are logged.
2. Persists build output as ~[`OCI images`](https://github.com/opencontainers/image-spec)~ Docker image tarballs against the workflow run.
3. If _all_ images built successfully, publishes to Docker Hub.

Resolves #10 and provides a clean insertion point for #7 and #12.