### PR TITLE
Add edge service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,9 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ matrix.service.repo }}#${{ matrix.service.sha }}
-        build-args: PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
+        build-args: |
+          PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
+          TARGET=${{ matrix.service.name }}
         outputs: type=docker,dest=image.tar
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "services/init"]
 	path = services/init
 	url = https://github.com/placeos/init.git
+[submodule "services/edge"]
+	path = services/edge
+	url = https://github.com/placeos/core.git


### PR DESCRIPTION
Adds compilation of `edge` to service builds.

This is intentionally listed as a seperate service ref to support building releases where `core` and `edge` may need to reference different upstream repo states. This is hopefully no required, but keeps that flexibility along with the ability to split these into discrete repos if they diverge over time.

`TARGET` build arg is passed to all image builders, but is safely ignore by those where it is not needed.

Closes #17.