### PR TITLE
docs: zero indexed revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Numbering reflects the original release packaging date (`YYMM`). This will perpe
 When moving to a new minor version deprecation warnings _may_ appear in API responses and logging, but functionality will remain.
 
 ### Revision
-Revisions increment within each minor version, resetting to `1`.
+Revisions increment within each minor version, resetting to `0`.
 These represent change to address a bug, feature limitation or security vulnerability in the originally packaged minor release.
 
 An increment to a release number can represent a change to one or more underlying services.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Platform versions overlay this to provide a set of compatible, deployable compon
 
 A platform version looks like:
 
-    placeos-1.2007.1
+    placeos-1.2104.1
             |  |   |
             |  |   revision
             |  |


### PR DESCRIPTION
Fixes an incorrect reference to revisions beginning at 1 as noted in https://github.com/place-labs/partner-environment/pull/29#pullrequestreview-630896312.