### PR TITLE
SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,71 @@
+# PlaceOS Vulnerability Disclosure Policy
+
+
+If you have found a security issue, *DO NOT* file a public issue.
+Please use the [official channels](#official-channels) below.
+
+
+## Introduction
+
+PlaceOS welcomes feedback from security researchers and the general public to help improve our security.
+If you believe you have discovered a vulnerability, privacy issue, exposed data, or other security issues in any of our assets or platform components, we want to hear from you.
+This policy outlines steps for reporting vulnerabilities to us, what we expect, what you can expect from us.
+
+
+## Scope
+
+This policy applies to any digital assets owned, operated, or maintained by PlaceOS, including public facing websites or published software.
+
+
+## Out of Scope
+
+- Assets or other equipment not owned by parties participating in this policy.
+- Deployed instances of PlaceOS not directly operated by Place Technology Limited.
+- Vulnerabilities discovered or suspected in out-of-scope systems should be reported to the appropriate vendor or applicable authority.
+
+
+## Our Commitments
+
+When working with us, according to this policy, you can expect us to:
+
+- Respond to your report promptly, and work with you to understand and validate your report;
+- Strive to keep you informed about the progress of a vulnerability as it is processed;
+- Work to remediate discovered vulnerabilities in a timely manner, within our operational contraints; and
+- Extend Safe Harbor for your vulnerability research that is related to this policy.
+
+
+## Our Expectations
+
+In participating in our vulnerability disclosure program in good faith, we ask that you:
+
+- Play by the rules, including following this policy and any other relevant agreements. If there is any inconsistency between this policy and any other applicable terms, the terms of this policy will prevail;
+- Report any vulnerability you’ve discovered promptly;
+- Avoid violating the privacy of others, disrupting our systems, destroying data, and/or harming user experience;
+- Use only the Official Channels to discuss vulnerability information with us;
+- Provide us a reasonable amount of time (at least 90 days from the initial report) to resolve the issue before you disclose it publicly;
+- Perform testing only on in-scope systems, and respect systems and activities which are out-of-scope;
+- If a vulnerability provides unintended access to data: Limit the amount of data you access to the minimum required for effectively demonstrating a Proof of Concept; and cease testing and submit a report immediately if you encounter any user data during testing, such as Personally Identifiable Information (PII), Personal Healthcare Information (PHI), credit card data, or proprietary information;
+- You should only interact with test accounts you own or with explicit permission from the account holder; and
+- Do not engage in extortion.
+
+
+## Official Channels
+
+Please use security@placeos.com to report security issues.
+
+
+## Safe Harbor
+
+When conducting vulnerability research, according to this policy, we consider this research conducted under this policy to be:
+
+- Authorized concerning any applicable anti-hacking laws, and we will not initiate or support legal action against you for accidental, good-faith violations of this policy;
+- Authorized concerning any relevant anti-circumvention laws, and we will not bring a claim against you for circumvention of technology controls;
+- Exempt from restrictions in our Terms of Service (TOS) and/or Acceptable Usage Policy (AUP) that would interfere with conducting security research, and we waive those restrictions on a limited basis; and
+- Lawful, helpful to the overall security of the Internet, and conducted in good faith.
+
+You are expected, as always, to comply with all applicable laws.
+If legal action is initiated by a third party against you and you have complied with this policy, we will take steps to make it known that your actions were conducted in compliance with this policy.
+
+If at any time you have concerns or are uncertain whether your security research is consistent with this policy, please submit a report through one of our Official Channels before going any further.
+
+> Note that the Safe Harbor applies only to legal claims under the control of the organization participating in this policy, and that the policy does not bind independent third parties.


### PR DESCRIPTION
Adds a `SECURITY.md` that details a vulnerability disclosure policy.

Wording of this is based on the template provided by [disclose.io](https://disclose.io/). This should be read, and discussed deeply before merge.