### PR TITLE
Image scans

### DIFF
--- a/.github/actions/platform-info/action.yml
+++ b/.github/actions/platform-info/action.yml
@@ -1,0 +1,63 @@
+name: Platform Info
+description: Introspects the repository structure for build and version details
+
+inputs:
+  ref:
+    description: git ref to introspect (branch, tag, or sha)
+    required: true
+
+outputs:
+  services:
+    description: JSON encoded list of objects containing service information
+    value: ${{ steps.introspect.outputs.services }}
+  version:
+    description: Platform version identifier
+    value: ${{ steps.version.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    -
+      name: Checkout release
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-depth: 0
+    -
+      name: Generate version number
+      id: version
+      shell: bash
+      run: |
+        branch=$(git branch --show-current)
+        if [[ $branch =~ ^[0-9]+\.[0-9]{4}$ ]]
+        then
+          echo ::debug::Generating platform version
+          offset=$(git rev-list origin/nightly.. --count)
+          echo ::set-output name=tag::placeos-$branch.$offset
+        else
+          echo ::debug::Not on a release branch, using branch name
+          echo ::set-output name=tag::$branch
+        fi
+    -
+      name: Discover services
+      id: introspect
+      shell: bash
+      run: |
+        echo ::set-output name=services::$(
+          git submodule--helper list services |
+          while read -r _ sha _ path; do
+            sm_name=$(git submodule--helper name $path)
+            name=$(basename $path)
+            repo=$(git submodule--helper config submodule.$sm_name.url)
+            echo "$name $path $repo $sha"
+          done |
+          jq -Rnc '. |= [ inputs | split(" ") |
+            {
+              name: .[0],
+              path: .[1],
+              repo: .[2],
+              href: .[2][:-4],
+              sha:  .[3],
+            }
+          ]'
+        )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - '[0-9].[0-9][0-9][0-9][0-9]'
 
+  workflow_dispatch:
+
 env:
   CRYSTAL_VERSION: 1.1.1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,52 +20,19 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.introspect.outputs.services }}
-      commit: ${{ steps.introspect.outputs.commit }}
-      version: ${{ steps.version.outputs.tag }}
+      version:  ${{ steps.introspect.outputs.version }}
+      commit:   ${{ github.sha }}
     name: Discover
     steps:
     -
-      name: Checkout release
+      name: Checkout local actions and scripts
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    -
-      name: Generate version number
-      id: version
-      run: |
-        branch=$(git branch --show-current)
-        if [[ $branch =~ ^[0-9]+\.[0-9]{4}$ ]]
-        then
-          echo ::debug::Generating platform version
-          offset=$(git rev-list origin/nightly.. --count)
-          echo ::set-output name=tag::placeos-$branch.$offset
-        else
-          echo ::debug::Not on a release branch, using branch name
-          echo ::set-output name=tag::$branch
-        fi
     -
       name: Discover services
       id:   introspect
-      run: |
-        echo ::set-output name=commit::$(git rev-parse HEAD)
-        echo ::set-output name=services::$(
-          git submodule--helper list services |
-          while read -r _ sha _ path; do
-            sm_name=$(git submodule--helper name $path)
-            name=$(basename $path)
-            repo=$(git submodule--helper config submodule.$sm_name.url)
-            echo "$name $path $repo $sha"
-          done |
-          jq -Rnc '. |= [ inputs | split(" ") |
-            {
-              name: .[0],
-              path: .[1],
-              repo: .[2],
-              href: .[2][:-4],
-              sha:  .[3],
-            }
-          ]'
-        )
+      uses: ./.github/actions/platform-info
+      with:
+        ref: ${{ github.ref }}
 
   build:
     needs: discover

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,49 +78,8 @@ jobs:
         name: ${{ matrix.service.name }}
         path: image.tar
 
-  scan:
-    needs:
-    - discover
-    - build
-    strategy:
-      matrix:
-        service: ${{ fromJson(needs.discover.outputs.services) }}
-        version:
-        - ${{ needs.discover.outputs.version }}
-      fail-fast: false
-    runs-on: ubuntu-latest
-    name: Scan ${{ matrix.service.name }}
-    steps:
-    -
-      name: Download image artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ${{ matrix.service.name }}
-    -
-      name: Load
-      run: docker load --input image.tar
-    -
-      name: Scan
-      uses: anchore/scan-action@v3
-      id: scan
-      with:
-        image: placeos/${{ matrix.service.name }}:${{ matrix.version }}
-        fail-build: true
-        severity-cutoff: critical
-        acs-report-enable: true
-        debug: true
-    -
-      name: Report
-      if: ${{ always() }}
-      uses: github/codeql-action/upload-sarif@v1
-      with:
-        sarif_file: ${{ steps.scan.outputs.sarif }}
-        category: ${{ github.workflow }}/${{ github.job }}/${{ matrix.service.path }}/${{ matrix.version }}/${{ github.run_id }}
-
   publish:
-    needs:
-    - build
-    - scan
+    needs: build
     runs-on: ubuntu-latest
     name: Publish
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,9 +109,48 @@ jobs:
         name: ${{ matrix.service.name }}
         path: image.tar
 
+  scan:
+    needs:
+    - discover
+    - build
+    strategy:
+      matrix:
+        service: ${{ fromJson(needs.discover.outputs.services) }}
+        version:
+        - ${{ needs.discover.outputs.version }}
+      fail-fast: false
+    runs-on: ubuntu-latest
+    name: Scan ${{ matrix.service.name }}
+    steps:
+    -
+      name: Download image artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ matrix.service.name }}
+    -
+      name: Load
+      run: docker load --input image.tar
+    -
+      name: Scan
+      uses: anchore/scan-action@v3
+      id: scan
+      with:
+        image: placeos/${{ matrix.service.name }}:${{ matrix.version }}
+        fail-build: true
+        severity-cutoff: critical
+        acs-report-enable: true
+    -
+      name: Report
+      if: ${{ always() }}
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif }}
+        category: ${{ github.workflow }}/${{ github.job }}/${{ matrix.service.path }}/${{ matrix.version }}/${{ github.run_id }}
+
   publish:
     needs:
     - build
+    - scan
     runs-on: ubuntu-latest
     name: Publish
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,7 @@ jobs:
         fail-build: true
         severity-cutoff: critical
         acs-report-enable: true
+        debug: true
     -
       name: Report
       if: ${{ always() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ env:
   CRYSTAL_VERSION: 1.1.1
 
 jobs:
-  platform-info:
+  discover:
     runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.introspect.outputs.services }}
       commit: ${{ steps.introspect.outputs.commit }}
       version: ${{ steps.version.outputs.tag }}
-    name: Prepare
+    name: Discover
     steps:
     -
       name: Checkout release
@@ -65,11 +65,11 @@ jobs:
           ]'
         )
 
-  build-services:
-    needs: platform-info
+  build:
+    needs: discover
     strategy:
       matrix:
-        service: ${{ fromJson(needs.platform-info.outputs.services) }}
+        service: ${{ fromJson(needs.discover.outputs.services) }}
       fail-fast: false
     runs-on: ubuntu-latest
     name: Build ${{ matrix.service.name }}
@@ -88,17 +88,17 @@ jobs:
         context: ${{ matrix.service.repo }}#${{ matrix.service.sha }}
         build-args: |
           CRYSTAL_VERSION=${{ env.CRYSTAL_VERSION }}
-          PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
-          PLACE_VERSION=${{ needs.platform-info.outputs.version }}
+          PLACE_COMMIT=${{ needs.discover.outputs.commit }}
+          PLACE_VERSION=${{ needs.discover.outputs.version }}
           TARGET=${{ matrix.service.name }}
         outputs: type=docker,dest=image.tar
         cache-from: type=gha,scope=${{ matrix.service.name }}
         cache-to: type=gha,scope=${{ matrix.service.name }},mode=max
-        tags: placeos/${{ matrix.service.name }}:${{ needs.platform-info.outputs.version }}
+        tags: placeos/${{ matrix.service.name }}:${{ needs.discover.outputs.version }}
         labels: |
           org.opencontainers.image.url=${{ matrix.service.href }}
           org.opencontainers.image.source=${{ matrix.service.href }}/tree/${{ matrix.service.sha }}
-          org.opencontainers.image.version=${{ needs.platform-info.outputs.version }}
+          org.opencontainers.image.version=${{ needs.discover.outputs.version }}
           org.opencontainers.image.revision=${{ matrix.service.sha }}
           org.opencontainers.image.vendor=Place Technology Limited
           org.opencontainers.image.title=${{ matrix.service.name }}
@@ -109,8 +109,9 @@ jobs:
         name: ${{ matrix.service.name }}
         path: image.tar
 
-  publish-images:
-    needs: build-services
+  publish:
+    needs:
+    - build
     runs-on: ubuntu-latest
     name: Publish
     steps:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -36,6 +36,9 @@ jobs:
     name: Scan ${{ matrix.service.name }}
     steps:
     -
+      name: Checkout
+      uses: actions/checkout@v2
+    -
       name: Pull
       run: docker pull placeos/${{ matrix.service.name }}:${{ matrix.version }}
     -

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,6 +1,9 @@
 name: Scan
 
 on:
+  schedule:
+  - cron: "0 20 * * *"
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,53 @@
+name: Scan
+
+on:
+  workflow_dispatch:
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.introspect.outputs.services }}
+      version:  ${{ steps.introspect.outputs.version }}
+    name: Discover
+    steps:
+    -
+      name: Checkout local actions and scripts
+      uses: actions/checkout@v2
+    -
+      name: Discover services
+      id:   introspect
+      uses: ./.github/actions/platform-info
+      with:
+        ref: ${{ github.ref }}
+
+  scan:
+    needs: discover
+    strategy:
+      matrix:
+        service: ${{ fromJson(needs.discover.outputs.services) }}
+        version:
+        - ${{ needs.discover.outputs.version }}
+      fail-fast: false
+    runs-on: ubuntu-latest
+    name: Scan ${{ matrix.service.name }}
+    steps:
+    -
+      name: Pull
+      run: docker pull placeos/${{ matrix.service.name }}:${{ matrix.version }}
+    -
+      name: Scan
+      uses: anchore/scan-action@v3
+      id: scan
+      with:
+        image: placeos/${{ matrix.service.name }}:${{ matrix.version }}
+        fail-build: true
+        severity-cutoff: critical
+        acs-report-enable: true
+    -
+      name: Report
+      if: ${{ always() }}
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif }}
+        category: ${{ github.workflow }}/${{ github.job }}/${{ matrix.service.path }}/${{ matrix.version }}/${{ github.run_id }}

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,4 @@
+# https://github.com/anchore/grype#specifying-matches-to-ignore
+
+ignore:
+


### PR DESCRIPTION
Integrates the use of [anchore/scan-action](https://github.com/anchore/scan-action) to perform a security scan of release artefacts ahead of publishing.

Following successful builds all images are scanned for known vulnerabilities. Internally this uses [grype](https://github.com/anchore/grype) and runs locally (within the actions runner context) only. This enables operation with dependancy on an external service (Snyk et al).

If an issue of `critical` severity is identified on _any_ service, publishing of _all_ services will be blocked to support atomic releases.

Example run: https://github.com/place-labs/PlaceOS/actions/runs/899414826

Issues of all severity are tracked against release assets and available under the security tab privately ([example](https://github.com/place-labs/PlaceOS/security/code-scanning)). These are fingerprinted to prevent duplication on subsequent builds and support dismissal in the case of false positives.

> Note: static analysis of source code _should_ still happen in upstream service repositories, this tooling focus on assets generated directly by this repository only.

Closes #12.