### PR TITLE
feat(build): add PLACE_VERSION build argument

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
         context: ${{ matrix.service.repo }}#${{ matrix.service.sha }}
         build-args: |
           PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
+          PLACE_VERSION=${{ needs.platform-info.outputs.version }}
           TARGET=${{ matrix.service.name }}
         outputs: type=docker,dest=image.tar
         cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
The `PLACE_VERSION` env var will be accessed via [`PlaceOS::Model::Version`](https://github.com/PlaceOS/models/blob/master/src/placeos-models/version.cr)