### PR TITLE
feat: add base CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to PlaceOS are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [PlaceOS Platform Versioning](./README.md#platform-versioning).
+
+
+## [Unreleased]
+
+
+## [1.2108.0]
+
+### Added
+- Support for `X-API-Key` header authorization.
+
+### Fixed
+- Missing default health check on `auth` service.
+- Attempted use of git credentials in encrypted form when cloning repositories.


### PR DESCRIPTION
Adds a base changelog, seeded with changes for `1.2108.0`.

Note: square brackets around release versions currently appear unlinked as we do not have tags against this repo. When added they will be parsed by the GitHub UI as seen here: https://github.com/olivierlacan/keep-a-changelog/blob/main/CHANGELOG.md.

Addresses #62.