### PR TITLE
Include staff-api in release packaging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "interfaces/templates"]
 	path = interfaces/templates
 	url = https://github.com/placeos/user-interfaces.git
+[submodule "services/staff-api"]
+	path = services/staff-api
+	url = https://github.com/placeos/staff-api.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [PlaceOS Platform Versioning](./README.md#platform-v
 
 ## [Unreleased]
 
+### Added
+- Inclusion of [`staff-api`](https://github.com/PlaceOS/staff-api) in release packaging.
+
 ### Fixed
 - Allow compilation of drivers that do not exist in default branches.
 


### PR DESCRIPTION
Provides immutable references for `staff-api` builds.

Resolves #86.