### PR TITLE
GHA cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,14 +78,6 @@ jobs:
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     -
-      name: Set up Docker Cache
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-${{ matrix.service.name }}-${{ matrix.service.sha }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.service.name }}-
-    -
       name: Build image
       id:   build
       uses: docker/build-push-action@v2
@@ -96,8 +88,8 @@ jobs:
           PLACE_VERSION=${{ needs.platform-info.outputs.version }}
           TARGET=${{ matrix.service.name }}
         outputs: type=docker,dest=image.tar
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         tags: placeos/${{ matrix.service.name }}:${{ needs.platform-info.outputs.version }}
         labels: |
           org.opencontainers.image.url=${{ matrix.service.href }}


### PR DESCRIPTION
Implements usage of direct [GitHub Actions cache](https://github.com/moby/buildkit/tree/master#github-actions-cache-experimental) now provided by buildx.

This addresses an issue where [new service builds would fail on initial run](https://github.com/PlaceOS/PlaceOS/runs/3437994216?check_suite_focus=true) due to missing cache and prevents [unbounded cache expansion](https://github.com/docker/build-push-action/issues/252).
