### PR TITLE
Update build repo path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,4 +48,4 @@
 	url = https://github.com/placeos/staff-api.git
 [submodule "services/build"]
 	path = services/build
-	url = https://github.com/PlaceOS/build
+	url = https://github.com/PlaceOS/build.git


### PR DESCRIPTION
Updates the submodule for `build` to reference full git URI.

Existing path was functional for clones, but not support when passed as a [build context](https://github.com/PlaceOS/PlaceOS/blob/c810cab53ae0a1babf952d3e26a1b0824fb17f77/.github/workflows/build.yml#L85).

Cause of failure in the following nightly runs:
- https://github.com/PlaceOS/PlaceOS/runs/3438361357?check_suite_focus=true
- https://github.com/PlaceOS/PlaceOS/runs/3445906765?check_suite_focus=true
- https://github.com/PlaceOS/PlaceOS/runs/3451454702?check_suite_focus=true
- https://github.com/PlaceOS/PlaceOS/runs/3455849800?check_suite_focus=true
