### PR TITLE
chore: rename `frontends` -> `frontend-loader`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,9 @@
 [submodule "services/dispatch"]
 	path = services/dispatch
 	url = https://github.com/placeos/dispatch.git
-[submodule "services/frontends"]
-	path = services/frontends
-	url = https://github.com/placeos/frontends.git
+[submodule "services/frontend-loader"]
+	path = services/frontend-loader
+	url = https://github.com/placeos/frontend-loader.git
 [submodule "clients/crystal"]
 	path = clients/crystal
 	url = https://github.com/placeos/crystal-client.git


### PR DESCRIPTION
Closes #118.

Previous versions will remain available under [`placeos/frontends`](https://hub.docker.com/repository/docker/placeos/frontends). Following merge publishing will redirect to [`placeos/frontend-loader`](https://hub.docker.com/repository/docker/placeos/frontend-loader).