### PR TITLE
docs(CHANGELOG): stage unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [PlaceOS Platform Versioning](./README.md#platform-v
 - Support commit listing on repositories using non-default branches.
 - Prevent repositories reverting to master branch.
 - Ensure reconnection to RethinkDB following write error.
+- Build `staff-api` service against crystal 1.1.1.
+- Ensure correct search index creation on boot.
+- Provide extended logging from `rubber-soul` service.
 
 ### Security
 - Add permissions check on event creation in `staff-api`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PlaceOS Platform Versioning](./README.md#platform-versioning).
 
 
-
-## Unreleased
+## 1.2109.1
 
 ### Changed
 - Use full commit hashes for repository pinning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ and this project adheres to [PlaceOS Platform Versioning](./README.md#platform-v
 - Prevent repositories reverting to master branch.
 - Ensure reconnection to RethinkDB following write error.
 - Build `staff-api` service against crystal 1.1.1.
-- Ensure correct search index creation on boot.
-- Provide extended logging from `rubber-soul` service.
+- Resolve replication issue for search indicies.
 
 ### Security
 - Add permissions check on event creation in `staff-api`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,23 @@ All notable changes to PlaceOS are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PlaceOS Platform Versioning](./README.md#platform-versioning).
 
+
+
 ## Unreleased
 
-- Fix healthcheck of `frontend-loader`.
-- Account for branches in commit listing in `rest-api`.
-- Fix `core` and `frontend-loader` resetting to master on git queries.
-- Fix rethinkdb driver reconnections on writes.
-- Fix token revocation in `auth`.
-- Improve handling of GraphAPI errors in `staff-api`.
+### Changed
+- Use full commit hashes for repository pinning.
+
+### Fixed
+- Update default healthcheck on `frontend-loader` service.
+- Support commit listing on repositories using non-default branches.
+- Prevent repositories reverting to master branch.
+- Ensure reconnection to RethinkDB following write error.
+
+### Security
 - Add permissions check on event creation in `staff-api`.
-- Full commits (as opposed to short commits) retrieved and stored against the `Repository` model.
+- Support refresh token revocation.
+
 
 ## 1.2109.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to PlaceOS are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PlaceOS Platform Versioning](./README.md#platform-versioning).
 
+## Unreleased
+
+- Fix healthcheck of `frontend-loader`.
+- Account for branches in commit listing in `rest-api`.
+- Fix `core` and `frontend-loader` resetting to master on git queries.
+- Fix rethinkdb driver reconnections on writes.
+- Fix token revocation in `auth`.
+- Improve handling of GraphAPI errors in `staff-api`.
+- Add permissions check on event creation in `staff-api`.
+- Full commits (as opposed to short commits) retrieved and stored against the `Repository` model.
 
 ## 1.2109.0
 


### PR DESCRIPTION
Documents unleased changes (compared to head of `1.2109`)