### PR TITLE
build(workflows/build): pass CRYSTAL_VERSION as a build arg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - '[0-9].[0-9][0-9][0-9][0-9]'
 
+env:
+  CRYSTAL_VERSION: 1.1.1
+
 jobs:
   platform-info:
     runs-on: ubuntu-latest
@@ -84,7 +87,7 @@ jobs:
       with:
         context: ${{ matrix.service.repo }}#${{ matrix.service.sha }}
         build-args: |
-          CRYSTAL_VERSION=1.1.1
+          CRYSTAL_VERSION=${{ env.CRYSTAL_VERSION }}
           PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
           PLACE_VERSION=${{ needs.platform-info.outputs.version }}
           TARGET=${{ matrix.service.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
       with:
         context: ${{ matrix.service.repo }}#${{ matrix.service.sha }}
         build-args: |
+          CRYSTAL_VERSION=1.1.1
           PLACE_COMMIT=${{ needs.platform-info.outputs.commit }}
           PLACE_VERSION=${{ needs.platform-info.outputs.version }}
           TARGET=${{ matrix.service.name }}


### PR DESCRIPTION
PlaceOS services support `CRYSTAL_VERSION` build arg in their Dockerfiles.

This change centralizes the version specification for the set of PlaceOS services.

To override the `CRYSTAL_VERSION` in an image, just comment out the argument