### PR TITLE
refactor: `rubber-soul` -> `search-ingest`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,8 +17,8 @@
 	path = services/source
 	url = https://github.com/placeos/source.git
 [submodule "services/rubber-soul"]
-	path = services/rubber-soul
-	url = https://github.com/placeos/rubber-soul.git
+	path = services/search-ingest
+	url = https://github.com/placeos/search-ingest.git
 [submodule "services/dispatch"]
 	path = services/dispatch
 	url = https://github.com/placeos/dispatch.git


### PR DESCRIPTION
Renames the `rubber-soul` submodule  to `search-ingest`

Any environment variable changes have been made backwards compatible, however if older env keys are referenced, a warning is produced.

Below is the list of updated constants
```
"PLACE_SEARCH_INGEST_HOST" <- "RUBBER_SOUL_HOST"
"PLACE_SEARCH_INGEST_PORT" <- "RUBBER_SOUL_PORT"
"ELASTIC_DISABLE_BULK" <- "ES_DISABLE_BULK"
"PLACE_SEARCH_INGEST_URI" <- "RUBBER_SOUL_URI"
"ELASTIC_TLS" <- "ES_TLS"
"ELASTIC_URI" <- "ES_URI"
"ELASTIC_HOST" <- "ES_HOST"
"ELASTIC_PORT" <- "ES_PORT"
"ELASTIC_CONN_POOL" <- "ES_CONN_POOL"
"ELASTIC_IDLE_POOL" <- "ES_IDLE_POOL"
"ELASTIC_CONN_POOL_TIMEOUT" <- "ES_CONN_POOL_TIMEOUT"
```