### PR TITLE
docs(CHANGELOG): add known partner environment issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [PlaceOS Platform Versioning](./README.md#platform-v
 - Improve cleanup of IO resources in drivers.
 - Resolve an issue where an event's hosts were included as a guest. ([#132](https://github.com/PlaceOS/staff-api/pull/132))
 
+## Known Issues
+- Fresh installs of the [`partner-environment`](https://github.com/place-labs/partner-environment) fail to generate secrets
+
 
 ## 1.2111.2
 


### PR DESCRIPTION
Adds a known issue with the partner environment to the CHANGELOG.md

- [x] https://github.com/place-labs/partner-environment/issues/87