### PR TITLE
feat: start of simpler release process

### DIFF
--- a/.github/actions/platform-info/action.yml
+++ b/.github/actions/platform-info/action.yml
@@ -28,16 +28,8 @@ runs:
       id: version
       shell: bash
       run: |
-        branch=$(git branch --show-current)
-        if [[ $branch =~ ^[0-9]+\.[0-9]{4}$ ]]
-        then
-          echo ::debug::Generating platform version
-          offset=$(git rev-list origin/nightly.. --count)
-          echo ::set-output name=tag::placeos-$branch.$offset
-        else
-          echo ::debug::Not on a release branch, using branch name
-          echo ::set-output name=tag::$branch
-        fi
+        echo ::debug::Using contents of VERSION file
+        echo ::set-output name=tag::$(cat VERSION)
     -
       name: Discover services
       id: introspect

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,10 @@ on:
 
   push:
     branches:
-      - '[0-9].[0-9][0-9][0-9][0-9]'
+      # Monthly releases
+      - '[0-9]+.[0-9][0-9][0-9][0-9]'
+      # Release candidates
+      - '[0-9]+.[0-9][0-9][0-9][0-9].[0-9]+-rc[0-9]+'
 
   workflow_dispatch:
 
@@ -41,6 +44,8 @@ jobs:
         service: ${{ fromJson(needs.discover.outputs.services) }}
       fail-fast: false
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.tags.outputs.tags }}
     name: Build ${{ matrix.service.name }}
     steps:
     -
@@ -49,6 +54,40 @@ jobs:
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+    -
+      name: Construct Tags
+      id: tags
+      run: |
+        branch=${GITHUB_REF#refs/*/}
+        version=${{ needs.discover.outputs.version }}
+
+        # This will default to the branch name if `VERSION` has not changed
+        tags=placeos/${{ matrix.service.name }}:${version}
+
+        # Update monthly tag if a version is created.
+        # i.e. Tag `1.2203` in addition to `1.2203.1`
+        if [[ $branch =~ ^[0-9]+\.[0-9]{4}$ ]]
+        then
+          tags="${tags},${branch}"
+        fi
+
+        # Add `latest` tag if creating newest version
+        latest_release_tag=$(git tag | grep -E '^[0-9]+\.[0-9]{4}\.[0-9]+$' | tail -1)
+        if [[ $version =~ ^[0-9]+\.[0-9]{4}\.[0-9]+$ && $version > $latest_release_tag ]]
+        then
+          tags="$tags,latest"
+        fi
+
+
+        # Add `preview` tag if creating newest preview version
+        latest_preview_tag=$(git tag | grep -E '^[0-9]+\.[0-9]{4}\.[0-9]+-rc[0-9]+$' | tail -1)
+        if [[ $version =~ ^[0-9]+\.[0-9]{4}\.[0-9]+-rc[0-9]+$ && $version > $latest_preview_tag ]]
+        then
+          tags="$tags,preview"
+        fi
+
+
+        echo ::set-output name=tags::$tags
     -
       name: Build image
       id:   build
@@ -63,7 +102,7 @@ jobs:
         outputs: type=docker,dest=image.tar
         cache-from: type=gha,scope=${{ matrix.service.name }}
         cache-to: type=gha,scope=${{ matrix.service.name }},mode=max
-        tags: placeos/${{ matrix.service.name }}:${{ needs.discover.outputs.version }}
+        tags: ${{ steps.tags.outputs.tags }}
         labels: |
           org.opencontainers.image.url=${{ matrix.service.href }}
           org.opencontainers.image.source=${{ matrix.service.href }}/tree/${{ matrix.service.sha }}
@@ -78,11 +117,45 @@ jobs:
         name: ${{ matrix.service.name }}
         path: image.tar
 
+  release:
+    needs:
+      - publish
+    environment: release
+    runs-on: ubuntu-latest
+    name: Tag and release
+    steps:
+      - name: Tag
+        shell: bash
+        run: |
+          # Iterate through tags from the build jobs, force updating tags (spooky)
+          IFS=','
+          read -ratags<<< "${{ needs.build.outputs.tags }}"
+          for tag in "${tags[@]}"; do
+            git tag --force $tag
+          done
+          IFS=''
+
+      # TODO: step to get the whether to create release or not
+      # - if $version is formatted like a release
+      #   - create a release with it
+      #     - body has link to the ref on github _with_ markdown anchor to correct version
+      #     - see if there's a way to embed a range of text from another file, like a code snippet.
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          # note you'll typically need to create a personal access token
+          # with permissions to create releases in the other repo
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+        env:
+          GITHUB_REPOSITORY: my_gh_org/my_gh_repo
+
   publish:
     needs:
       - build
       - discover
     runs-on: ubuntu-latest
+    environment: release
     name: Publish
     steps:
     -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,13 @@ on:
       # Monthly releases
       - '[0-9]+.[0-9][0-9][0-9][0-9]'
       # Release candidates
-      - '[0-9]+.[0-9][0-9][0-9][0-9].[0-9]+-rc[0-9]+'
+      - '[0-9]+.[0-9][0-9][0-9][0-9].[0-9]+-preview'
 
   workflow_dispatch:
 
 env:
   CRYSTAL_VERSION: 1.3.2
+  RELEASE_REPO: PlaceOS/PlaceOS
 
 jobs:
   discover:
@@ -117,39 +118,6 @@ jobs:
         name: ${{ matrix.service.name }}
         path: image.tar
 
-  release:
-    needs:
-      - publish
-    environment: release
-    runs-on: ubuntu-latest
-    name: Tag and release
-    steps:
-      - name: Tag
-        shell: bash
-        run: |
-          # Iterate through tags from the build jobs, force updating tags (spooky)
-          IFS=','
-          read -ratags<<< "${{ needs.build.outputs.tags }}"
-          for tag in "${tags[@]}"; do
-            git tag --force $tag
-          done
-          IFS=''
-
-      # TODO: step to get the whether to create release or not
-      # - if $version is formatted like a release
-      #   - create a release with it
-      #     - body has link to the ref on github _with_ markdown anchor to correct version
-      #     - see if there's a way to embed a range of text from another file, like a code snippet.
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          # note you'll typically need to create a personal access token
-          # with permissions to create releases in the other repo
-          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-        env:
-          GITHUB_REPOSITORY: my_gh_org/my_gh_repo
-
   publish:
     needs:
       - build
@@ -200,3 +168,53 @@ jobs:
           name: Build PlaceOS ${{ needs.discover.outputs.version }}
           url: ${{ secrets.CHAT_ERROR }}
           status: ${{ job.status }}
+
+  release:
+    needs:
+      - discover
+      - publish
+    environment: release
+    runs-on: ubuntu-latest
+    name: Tag and release
+    steps:
+      - name: Tag
+        shell: bash
+        run: |
+          # Iterate through tags from the build jobs, force updating tags (spooky)
+          IFS=','
+          read -ratags<<< "${{ needs.build.outputs.tags }}"
+          for tag in "${tags[@]}"; do
+            git tag --force $tag
+          done
+          IFS=''
+
+      - id: prepare-release
+        run: |
+          # Check if $version is formatted like a release
+          version=${{ needs.discover.outputs.version }}
+          if [[ $version =~ ^[0-9]+\.[0-9]{4}\.[0-9]+$ ]]
+          then
+            should_release=true
+          else
+            should_release=false
+          fi
+          echo ::set-output name=should-release::$should_release
+
+          # Generate anchor to point to CHANGELOG heading in release notes
+          anchor=$(echo $version | tr -d '.')
+          echo ::set-output name=anchor::$anchor
+
+      # Create a release
+      # - The body has link to the ref on github _with_ markdown anchor to correct version.
+      #
+      # TODO: See if there's a way to embed a range of text from the CHANGELOG, like a code snippet.
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: ${{ steps.prepare-release.outputs.should-release }}
+        with:
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          generate_release_notes: false
+          repository: ${{ env.RELEASE_REPO }}
+          tag_name: ${{ needs.discover.outputs.version }}
+          body: |
+            See the [`CHANGELOG`](https://github.com/${{ env.RELEASE_REPO }}/blob/${{ needs.discover.outputs.version }}/CHANGELOG.md#${{ steps.prepare-release.outputs.anchor }}) for release notes.

--- a/README.md
+++ b/README.md
@@ -60,18 +60,15 @@ These are ephemeral and _do not_ have a corresponding platform version.
 
 Intended primarily for development environments.
 
-### `preview`
-References the latest release candidate.
-This may contain issues that do not present within test environments.
-
-Releases on this channel are suitable for staging and canary deployments.
-
 ### `latest`
 Main release channel.
-This tails `preview` by one minor release cycle.
 
 Recommended for production environments.
 
+### `preview`
+The latest preview build.
+
+**NOT** recommended for production environments.
 
 ## Release Artefacts
 


### PR DESCRIPTION
**Description of the change**

Simplifies the release process to use a `VERSION` file.
The same branches trigger releases as before, i.e. the major versions.
Additionally, preview branches of the form `{major}.{calver minor}.{patch}-preview` will trigger and publish builds, however the `VERSION` file _must_ contain versions formatted `{major}.{calver minor}.{patch}-rc{revision}`

In the short term, this should make it easier to manage versions

We can improve this process gradually.

ATM, `CHANGELOG` generation is pretty manual.

@chillfox suggested a `.script/update.cr` that will handle automation around releasing.
That can either be a PR to this, or a be selected for further development later

**Relevant Issues**

- Closes #76
