### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/product-requirements.md
+++ b/.github/ISSUE_TEMPLATE/product-requirements.md
@@ -1,0 +1,63 @@
+---
+name: Product Requirements
+about: Product Requirement Template
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+|Element|Details|
+|----|----|
+| Document status | DRAFT |
+| Development Status | NOT STARTED |
+| Document owner |  |
+| Designer |  |
+| Developers | |
+| QA | |
+| Request Contact |  |
+
+### Objective
+---------
+
+-   
+
+### User Story & Relevant Background
+--------------------------------
+
+
+### Assumptions
+-----------
+
+-   
+
+### Requirements
+------------
+
+| # | Title | User Story | Importance | Notes |
+|----|----|----|----|----|
+| 1 | Title |As a xyz I want to xyz so I can xyz | Must Have/Nice to Have/Should Have|  |
+
+### Technical Design
+----------------
+
+Include any mockups, diagrams or visual designs relating to these requirements.
+
+### Questions
+---------
+
+Below is a list of questions to be addressed as a result of this requirements document:
+
+| Question | Outcome |
+|----|----|
+|  |  |
+
+### Notes
+-----
+
+Include any relevant notes or discussions relating to this design.
+
+### Out of Scope
+------------
+
+-   List the features discussed which are out of scope or might be revisited in a later release.


### PR DESCRIPTION
Add a PRD Issue template to fully document product feature requirements directly into the Epic rather than in Confluence