### PR TITLE
Fix nightly scan category

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -56,4 +56,4 @@ jobs:
       uses: github/codeql-action/upload-sarif@v1
       with:
         sarif_file: ${{ steps.scan.outputs.sarif }}
-        category: ${{ github.workflow }}/${{ github.job }}/${{ matrix.service.path }}/${{ matrix.version }}/${{ github.run_id }}
+        category: ${{ github.workflow }}/${{ github.job }}/${{ matrix.service.path }}/${{ matrix.version }}


### PR DESCRIPTION
**Description of the change**

Hello from GitHub Code Scanning! 😄👋 

We noticed your repo had an unusually large number of active categories, which I think was unintended.

By including the run ID in the category name, each scan will create a new category. 
This means you won't be able to track alert changes between two different runs of the same tool.
Similarly, if an alert is fixed in recent runs, it will continue to appear as open because it's still present in all the other scan categories.

**Benefits**

Ensures Code Scanning works as expected, allows the correct management of alerts.

**Possible drawbacks**

None?

**Additional information**

Unfortunately, you'll still be stuck with all the old categories unless you manually delete them via the API. 
If it makes things easier, we can clean them up for you.
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
