### PR TITLE
feat: remove search-ingest service (PPT-2644)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,9 +58,6 @@
 [submodule "libraries/placeos-log-backend"]
 	path = libraries/placeos-log-backend
 	url = https://github.com/place-labs/log-backend
-[submodule "services/search-ingest"]
-	path = services/search-ingest
-	url = https://github.com/placeos/search-ingest.git
 [submodule "services/build_service"]
 	path = services/build_service
 	url = https://github.com/placeos/build_service.git

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ These reference commits used to construct the built artefacts at each release.
 
 [![Rest API](https://img.shields.io/github/actions/workflow/status/PlaceOS/rest-api/ci.yml?label=rest-api&logo=github)](https://github.com/PlaceOS/rest-api/actions/workflows/ci.yml)
 
-[![Search Ingest](https://img.shields.io/github/actions/workflow/status/PlaceOS/search-ingest/ci.yml?label=search-ingest&logo=github)](https://github.com/PlaceOS/search-ingest/actions/workflows/ci.yml)
 
 [![Source](https://img.shields.io/github/actions/workflow/status/PlaceOS/source/ci.yml?label=source&logo=github)](https://github.com/PlaceOS/source/actions/workflows/ci.yml)
 


### PR DESCRIPTION

Part of [PPT-2644](https://acaprojects.atlassian.net/browse/PPT-2644) (migrate search from Elasticsearch to PostgreSQL full-text search). The query side is merged and live — models#324/#325 and rest-api#445 ship search directly from PostgreSQL, verified healthy on nightly — so the PG→Elasticsearch indexer is retired and the platform stops building it.

## What's removed

- `services/search-ingest` submodule (`.gitmodules` entry + gitlink)
- its README build badge

Three deletions; nothing else. No workflow edits are needed: the build/publish matrix is derived from the submodule list at runtime (`.github/actions/platform-info` enumerates `git submodule status | grep services`), and the nightly Update pointer-bump job iterates the same set, so dropping the submodule drops the service from both.

## Verification

- `git submodule status | grep -i search` → empty; no `search-ingest` section in `.gitmodules`
- diff vs `nightly` is exactly the three deletions above
- residual-reference sweep over tracked meta files: only historical CHANGELOG entries, plus `shard-report.yml`'s shard list naming `neuroplastic` — a passive version-report list that already tolerates absent shards (it still names `rethinkdb`), left untouched

## Merge order

Once this merges, search-ingest is no longer built or published on nightly (already-published images are unaffected). The `PlaceOS/search-ingest` repository itself gets archived separately afterwards. Runtime removal of the service and Elasticsearch from deployments is handled in the companion infra PRs (helm chart, local compose, init).


[PPT-2644]: https://acaprojects.atlassian.net/browse/PPT-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ